### PR TITLE
WIP: Substitue sqllite with mariadb as backend database for PowerDNS auth server

### DIFF
--- a/prototypes/dns/README.md
+++ b/prototypes/dns/README.md
@@ -61,3 +61,10 @@ The setup script accepts the cluster id and an optional clusternameprefix parame
 
 To teardown the kind clusters simply execute:
 ./destroy-kind.sh 2
+
+### Check MariaDB Records:
+- Get DB root password: `kubectl get secret --namespace dns mariadb -o jsonpath="{.data.mariadb-root-password}" | base64 -d`
+- Connect to mariadb pod and execute `mariadb -uroot -p`
+- `SHOW DATABASES;`
+- `USE powerdns;`
+- `SHOW Tables;`

--- a/prototypes/dns/base/pdns-config.yaml
+++ b/prototypes/dns/base/pdns-config.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pdns-config
+  namespace: dns
+data:
+  pdns.conf: |
+    local-address=0.0.0.0
+    launch=gmysql
+    gmysql-host=mariadb.dns.svc.cluster.local
+    gmysql-user=root
+    api-key=auth_key
+    api=true
+    webserver=yes
+    webserver-port=8081
+    webserver-address=0.0.0.0
+    webserver-allow-from=0.0.0.0/0
+    secondary=false
+    dnsupdate=false
+    loglevel=7
+  unused.conf: |
+    #The following have default values "powerdns"
+    gmysql-user=powerdns
+    gmysql-dbname=powerdns

--- a/prototypes/dns/base/pdns-deploy.yaml
+++ b/prototypes/dns/base/pdns-deploy.yaml
@@ -15,11 +15,19 @@ spec:
     spec:
       containers:
       - name: pdns
+        args: # From dmc
+          - --gmysql-password=$(MARIADB_PASS)
+        #  - --api-key=$(POWERDNS_API_KEY)
         image: powerdns/pdns-auth-49:4.9.4
         imagePullPolicy: IfNotPresent
         env:
         - name: PDNS_AUTH_API_KEY
           value: "auth_key"
+        - name: MARIADB_PASS
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password # Check which key needs to be used for powerdns user
         ports:
         - name: dns-udp
           containerPort: 53
@@ -33,3 +41,17 @@ spec:
         securityContext:
           runAsUser: 0
           runAsGroup: 0
+        readinessProbe:
+          httpGet:
+            path: /
+            port: api
+        volumeMounts:
+        - name: pdns-config-volume
+          mountPath: /etc/powerdns/pdns.conf
+          subPath: pdns.conf
+          readOnly: true
+      volumes:
+        - name: pdns-config-volume
+          configMap:
+            name: pdns-config
+

--- a/prototypes/dns/setup-kind.sh
+++ b/prototypes/dns/setup-kind.sh
@@ -136,6 +136,7 @@ for cluster in $clusters; do
 
   RELEASE_NAME=external-dns-$cluster_id
   helm upgrade --install --namespace $ns --kube-context kind-$clustername $RELEASE_NAME oci://registry-1.docker.io/bitnamicharts/external-dns --version $external_dns_chart_version -f $tmp_config --set txtOwnerId=$clustername-
+  # helm install --namespace $ns --kube-context kind-$clustername mariadb oci://registry-1.docker.io/bitnamicharts/mariadb -f $tmp_config_mariadb
   # Create a rolebinding for the external-dns service account to allow read of the dnsendpoints crd if it does not exist
   if kubectl --context kind-$clustername get clusterrolebinding dnsendpoint-read-binding-$cluster_id >/dev/null 2>&1; then
     echo "ClusterRoleBinding 'dnsendpoint-read-binding-$cluster_id' already exists. Skipping creation."
@@ -144,6 +145,9 @@ for cluster in $clusters; do
     kubectl --context kind-$clustername create clusterrolebinding dnsendpoint-read-binding-$cluster_id --namespace=dns --clusterrole=dnsendpoint-read --serviceaccount=dns:external-dns-$cluster_id
   fi
 done
+
+# Install mariadb
+helm install --namespace $ns --kube-context kind-$clustername mariadb oci://registry-1.docker.io/bitnamicharts/mariadb -f ./templates/mariadb-values.yaml
 
 # Install CoreDNS
 values_file="templates/core-dns-values.yaml"

--- a/prototypes/dns/templates/mariadb-values.yaml
+++ b/prototypes/dns/templates/mariadb-values.yaml
@@ -1,0 +1,106 @@
+---
+##
+## MariaDB chart configuration
+## Defaults: https://github.com/bitnami/charts/blob/master/bitnami/mariadb/values.yaml
+##
+
+# global:
+#   security:
+#     allowInsecureImages: true
+
+# image:
+#   registry: registry-1.docker.io
+#   repository: bitnami/mariadb
+#   pullPolicy: IfNotPresent
+
+fullnameOverride: mariadb
+architecture: standalone
+
+auth:
+  username: powerdns
+  database: powerdns
+
+primary:
+  name: master
+  persistence:
+    enabled: true
+    accessModes:
+      - ReadWriteOnce
+    size: 8Gi
+
+initdbScripts:
+  powerdns-schema.sql: |
+    CREATE TABLE domains (
+      id                    INT AUTO_INCREMENT,
+      name                  VARCHAR(255) NOT NULL,
+      master                VARCHAR(128) DEFAULT NULL,
+      last_check            INT DEFAULT NULL,
+      type                  VARCHAR(8) NOT NULL,
+      notified_serial       INT UNSIGNED DEFAULT NULL,
+      account               VARCHAR(40) CHARACTER SET 'utf8' DEFAULT NULL,
+      options               VARCHAR(64000) DEFAULT NULL,
+      catalog               VARCHAR(255) DEFAULT NULL,
+      PRIMARY KEY (id)
+    ) Engine=InnoDB CHARACTER SET 'latin1';
+    CREATE UNIQUE INDEX name_index ON domains(name);
+    CREATE INDEX catalog_idx ON domains(catalog);
+    CREATE TABLE records (
+      id                    BIGINT AUTO_INCREMENT,
+      domain_id             INT DEFAULT NULL,
+      name                  VARCHAR(255) DEFAULT NULL,
+      type                  VARCHAR(10) DEFAULT NULL,
+      content               VARCHAR(64000) DEFAULT NULL,
+      ttl                   INT DEFAULT NULL,
+      prio                  INT DEFAULT NULL,
+      disabled              TINYINT(1) DEFAULT 0,
+      ordername             VARCHAR(255) BINARY DEFAULT NULL,
+      auth                  TINYINT(1) DEFAULT 1,
+      PRIMARY KEY (id)
+    ) Engine=InnoDB CHARACTER SET 'latin1';
+    CREATE INDEX nametype_index ON records(name,type);
+    CREATE INDEX domain_id ON records(domain_id);
+    CREATE INDEX ordername ON records (ordername);
+    CREATE TABLE supermasters (
+      ip                    VARCHAR(64) NOT NULL,
+      nameserver            VARCHAR(255) NOT NULL,
+      account               VARCHAR(40) CHARACTER SET 'utf8' NOT NULL,
+      PRIMARY KEY (ip, nameserver)
+    ) Engine=InnoDB CHARACTER SET 'latin1';
+    CREATE TABLE comments (
+      id                    INT AUTO_INCREMENT,
+      domain_id             INT NOT NULL,
+      name                  VARCHAR(255) NOT NULL,
+      type                  VARCHAR(10) NOT NULL,
+      modified_at           INT NOT NULL,
+      account               VARCHAR(40) CHARACTER SET 'utf8' DEFAULT NULL,
+      comment               TEXT CHARACTER SET 'utf8' NOT NULL,
+      PRIMARY KEY (id)
+    ) Engine=InnoDB CHARACTER SET 'latin1';
+    CREATE INDEX comments_name_type_idx ON comments (name, type);
+    CREATE INDEX comments_order_idx ON comments (domain_id, modified_at);
+    CREATE TABLE domainmetadata (
+      id                    INT AUTO_INCREMENT,
+      domain_id             INT NOT NULL,
+      kind                  VARCHAR(32),
+      content               TEXT,
+      PRIMARY KEY (id)
+    ) Engine=InnoDB CHARACTER SET 'latin1';
+    CREATE INDEX domainmetadata_idx ON domainmetadata (domain_id, kind);
+    CREATE TABLE cryptokeys (
+      id                    INT AUTO_INCREMENT,
+      domain_id             INT NOT NULL,
+      flags                 INT NOT NULL,
+      active                BOOL,
+      published             BOOL DEFAULT 1,
+      content               TEXT,
+      PRIMARY KEY(id)
+    ) Engine=InnoDB CHARACTER SET 'latin1';
+    CREATE INDEX domainidindex ON cryptokeys(domain_id);
+    CREATE TABLE tsigkeys (
+      id                    INT AUTO_INCREMENT,
+      name                  VARCHAR(255),
+      algorithm             VARCHAR(50),
+      secret                VARCHAR(255),
+      PRIMARY KEY (id)
+    ) Engine=InnoDB CHARACTER SET 'latin1';
+    CREATE UNIQUE INDEX namealgoindex ON tsigkeys(name, algorithm);

--- a/prototypes/dns/templates/mariadb-values.yaml
+++ b/prototypes/dns/templates/mariadb-values.yaml
@@ -19,6 +19,7 @@ architecture: standalone
 auth:
   username: powerdns
   database: powerdns
+  #password: "newUserPassword123"
 
 primary:
   name: master


### PR DESCRIPTION
This PR contains all the building blocks for transitioning from SQLite to MariaDB.

MariaDB is installed in the local clusters via a helm chart provided from bitnami.
MariaDB is initialized with .sql script which builds the required schema for PowerDNS.

PowerDNS deployment is configured to use MariaDB Service as backend.

Unfortunately is not yet functional, while the PowerDNS pod gets deployed, records are not stored in the backend, neither nslookup requests are served properly.
Some investigation is needed in  PowerDNS to MariaDB authentication, and PowerDNS Api Key.
